### PR TITLE
use new image service

### DIFF
--- a/assets/scss/components/article-series.scss
+++ b/assets/scss/components/article-series.scss
@@ -12,7 +12,7 @@
   &.active {
     & > span {
       &:before {
-        background-image: url(//image.webservices.ft.com/v1/images/raw/fticon-v1:arrow-down?source=Alphaville);
+        background-image: url(https://www.ft.com/__origami/service/image/v2/images/raw/fticon-v1:arrow-down?source=Alphaville);
       }
     }
   }
@@ -22,7 +22,7 @@
     display: inline-block;
     position: relative;
     &:before {
-      background-image: url(//image.webservices.ft.com/v1/images/raw/fticon-v1:arrow-right?source=Alphaville);
+      background-image: url(https://www.ft.com/__origami/service/image/v2/images/raw/fticon-v1:arrow-right?source=Alphaville);
       background-repeat: no-repeat;
       background-size: contain;
       background-color: transparent;

--- a/assets/scss/meet-the-team.scss
+++ b/assets/scss/meet-the-team.scss
@@ -84,7 +84,7 @@ $contact_color: #27757b;
 	.twitter {
 		a:before {
 			content: '';
-			background: url(http://image.webservices.ft.com/v1/images/raw/ftsocial:twitter?source=alphaville&format=png&width=15) no-repeat;
+			background: url(http://www.ft.com/__origami/service/image/v2/images/raw/ftsocial:twitter?source=alphaville&format=png&width=15) no-repeat;
 			width: 15px;
 			height: 15px;
 			display: inline-block;

--- a/views/helpers/image.js
+++ b/views/helpers/image.js
@@ -8,7 +8,7 @@ module.exports = (imgUrl, width, quality) => {
 	quality = Handlebars.escapeExpression(quality) || 'low';
 	const parsedImgUrl = url.parse(imgUrl, true);
 	if (parsedImgUrl.host !== 'image.webservices.ft.com') {
-		return `https://image.webservices.ft.com/v1/images/raw/${encodeURIComponent(imgUrl)}?source=Alphaville&width=${width}&quality=${quality}`;
+		return `https://www.ft.com/__origami/service/image/v2/images/raw/${encodeURIComponent(imgUrl)}?source=Alphaville&width=${width}&quality=${quality}`;
 	}
 	parsedImgUrl.query = _.extend({}, parsedImgUrl.query, {source:'Alphaville', width, quality});
 	parsedImgUrl.search = undefined;


### PR DESCRIPTION
We launched the new image service 6 days ago, I'm currently going around FT projects and helping them migrate to it.

The new Image Service includes a lot of improvements:
- The application is multi-region with failover
- We use stale-on-error and stale-while-revalidate cache extensions to ensure users get stale content if the application errors or has to revalidate an image
- We serve much smaller WebP and JPEG XR images to supported browsers
- We’ve seen a reduction in file size for a large number of image requests
- We’re now serving images over H2