### PR TITLE
Fix o-comments-beta not displaying in production

### DIFF
--- a/lib/controllers/articleCtrl.js
+++ b/lib/controllers/articleCtrl.js
@@ -66,8 +66,8 @@ exports.byVanity = function (req, res, next) {
 				.then(mostRecentPost => {
 
 					// Temporary addition until the comments are replaced
-					const flags = req.cookies['next-flags'];
-					const commentsTalkReplacement = flags && flags.indexOf('commentsTalkReplacement:on') >= 0;
+					const flags = req.get('next-flags');
+					const commentsTalkReplacement = flags && flags.indexOf(encodeURIComponent('commentsTalkReplacement:on')) >= 0;
 
 					res.render('article', {
 						title: article.title + ' | FT Alphaville',


### PR DESCRIPTION
We have discrovered that Alphaville Fastly configuration is stripping off all cookies from the request. Therefore the next-flags cookie was not making its way up to the article controller.

To fix this;
* Updated the Fastly configuration to write the contents of the next-flags cookie into a request header named next-flags.
* Updated the article controller to use the value from the header instead of the cookie.