### PR TITLE
Show Coral Talk for articles published after migration start date

### DIFF
--- a/assets/js/article.js
+++ b/assets/js/article.js
@@ -1,5 +1,5 @@
 require('./common');
-if (window.commentsTalkReplacement || window.useCoralTalk) {
+if (window.commentsTalkReplacement || window.commentsUseCoralTalk) {
 	// Temporary addition until the comments are replaced
 	require('o-comments-beta');
 } else {

--- a/assets/js/article.js
+++ b/assets/js/article.js
@@ -1,5 +1,5 @@
 require('./common');
-if (window.commentsTalkReplacement) {
+if (window.commentsTalkReplacement || window.useCoralTalk) {
 	// Temporary addition until the comments are replaced
 	require('o-comments-beta');
 } else {

--- a/lib/controllers/articleCtrl.js
+++ b/lib/controllers/articleCtrl.js
@@ -70,9 +70,9 @@ exports.byVanity = function (req, res, next) {
 					const commentsTalkReplacement = flags && flags.indexOf(encodeURIComponent('commentsTalkReplacement:on')) >= 0;
 
 					const commentsUseCoralMilestoneDate = process.env.COMMENTS_USE_CORAL_MILESTONE_DATE;
-					const commentsUseCoralTalk = process.env.COMMENTS_USE_CORAL_TALK === 'true';
+					const commentsUseCoralTalkFlag = process.env.COMMENTS_USE_CORAL_TALK === 'true';
 					let useCoralTalk = false;
-					if (commentsUseCoralMilestoneDate && commentsUseCoralTalk && article.firstPublishedDate > commentsUseCoralMilestoneDate) {
+					if (commentsUseCoralMilestoneDate && commentsUseCoralTalkFlag && article.firstPublishedDate > commentsUseCoralMilestoneDate) {
 						useCoralTalk = true;
 					}
 

--- a/lib/controllers/articleCtrl.js
+++ b/lib/controllers/articleCtrl.js
@@ -69,6 +69,13 @@ exports.byVanity = function (req, res, next) {
 					const flags = req.get('next-flags');
 					const commentsTalkReplacement = flags && flags.indexOf(encodeURIComponent('commentsTalkReplacement:on')) >= 0;
 
+					const commentsUseCoralMilestoneDate = process.env.COMMENTS_USE_CORAL_MILESTONE_DATE;
+					const commentsUseCoralTalk = process.env.COMMENTS_USE_CORAL_TALK === 'true';
+					let useCoralTalk = false;
+					if (commentsUseCoralMilestoneDate && commentsUseCoralTalk && article.firstPublishedDate > commentsUseCoralMilestoneDate) {
+						useCoralTalk = true;
+					}
+
 					res.render('article', {
 						title: article.title + ' | FT Alphaville',
 						article: article,
@@ -78,6 +85,7 @@ exports.byVanity = function (req, res, next) {
 							articleSeriesUrl,
 							image: imageHelper
 						},
+						useCoralTalk,
 						commentsTalkReplacement,
 						oComments: true,
 						adZone: (article.seriesArticles && article.seriesArticles.series.prefLabel === 'Alphachat' ? 'alpha.chat' : undefined)

--- a/views/article.handlebars
+++ b/views/article.handlebars
@@ -31,7 +31,7 @@
 	{{/commentsTalkReplacement}}
 	{{#useCoralTalk}}
 	<script>
-		window.useCoralTalk = true;
+		window.commentsUseCoralTalk = true;
 	</script>
 	{{/useCoralTalk}}
 	<script>

--- a/views/article.handlebars
+++ b/views/article.handlebars
@@ -29,6 +29,11 @@
 		window.commentsTalkReplacement = true;
 	</script>
 	{{/commentsTalkReplacement}}
+	{{#useCoralTalk}}
+	<script>
+		window.useCoralTalk = true;
+	</script>
+	{{/useCoralTalk}}
 	<script>
 		(function () {
 			ctmLoadScript({


### PR DESCRIPTION
For articles published after a certain date (which is not decided yet) we will start using Coral Talk.

This relies on two environment variables named COMMENTS_USE_CORAL_TALK and COMMENTS_USE_CORAL_MILESTONE_DATE.

COMMENTS_USE_CORAL_TALK needs to be set to `true` for this to work.

COMMENTS_USE_CORAL_MILESTONE_DATE defines at which point we start using Coral Talk. Articles published before that date will be rendered with Livefyre, and those that are published after that date will be rendered with Coral.

If COMMENTS_USE_CORAL_TALK is not true or COMMENTS_USE_CORAL_MILESTONE_DATE is not set, the page will render with Livefyre.