### PR TITLE
Bump o-comments-beta to v6.0.0-beta.12

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,7 @@
     "webchat": "Financial-Times/webchat#^2.1.0",
     "o-autoinit": "^1.2.0",
     "o-comments": "^4.0.0",
-		"o-comments-beta": "https://github.com/Financial-Times/o-comments.git#v6.0.0-beta.9",
+		"o-comments-beta": "https://github.com/Financial-Times/o-comments.git#v6.0.0-beta.12",
 		"o-comment-count": "^0.3.0",
     "o-tabs": "^4.0.0",
     "o-video": "^4.0.0",

--- a/views/article.handlebars
+++ b/views/article.handlebars
@@ -23,6 +23,8 @@
     <link rel="amphtml" href="https://amp.ft.com/content/{{article.id}}" />
 
 	<link rel="stylesheet" href="{{assetsBasePath}}/build/article.css" />
+
+	<link rel="canonical" href="{{article.webUrl}}" />
 	{{#commentsTalkReplacement}}
 	<script>
 		// Temporary addition until the comments are replaced
@@ -120,7 +122,7 @@
 
                 {{#article.comments.enabled}}
                     <a name="comments"></a>
-                    <div data-o-component="o-comments" data-o-comments-config-title="{{article.originalTitle}}" data-o-comments-config-url="{{@root.appUrl}}{{article.av2WebUrl}}" data-o-comments-config-articleId="{{article.id}}"></div>
+                    <div id="comments" data-o-component="o-comments" data-o-comments-config-title="{{article.originalTitle}}" data-o-comments-config-url="{{@root.appUrl}}{{article.av2WebUrl}}" data-o-comments-config-articleId="{{article.id}}"></div>
                 {{/article.comments.enabled}}
 
             </div>


### PR DESCRIPTION
This will allow us to get Coral v5 in Alphaville. It will only be available behind the `coralTalkReplacement` flag.