### PR TITLE
HACK: make one particular Alphaville article free

### DIFF
--- a/routes/__access_metadata.js
+++ b/routes/__access_metadata.js
@@ -5,6 +5,9 @@ const fetch = require('node-fetch');
 
 
 const av2AccessMetadata = [{
+	path_regex: "/2019/07/17/1563366942000/Cryptokitties-get-duplicated-at-Vaudeville-with-Simon-Denny.*",
+	classification: "unconditional" //AG: hack to make this one article free because Alphaville uses Wordpress for Access
+}, {
 	path_regex: "/curation.*",
 	classification: "conditional_registered"
 }, {


### PR DESCRIPTION
So:
* access.ft.com uses ftalphaville.ft.com/__access-metadata to determine if a URL is free
* ftalphaville.ft.com/__access-metadata uses Wordpress's /__access-metadata to generate itself.
* Wordpress is no longer used for Alphaville 😬 
* Therefore Spark-created articles can't be made free.

This is obviously a hack. Making Alphaville articles free is very rare - but hard coding this one will allow them to get this one promotional article free.