### PR TITLE
Update o-comments-beta version to v6.0.0-beta.17

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,7 @@
     "webchat": "Financial-Times/webchat#^2.1.0",
     "o-autoinit": "^1.2.0",
     "o-comments": "^5.1.1",
-    "o-comments-beta": "https://github.com/Financial-Times/o-comments.git#v6.0.0-beta.9",
+    "o-comments-beta": "https://github.com/Financial-Times/o-comments.git#v6.0.0-beta.17",
     "o-tabs": "^4.0.0",
     "o-video": "^4.0.0",
     "o-expander": "^4.0.0",


### PR DESCRIPTION
We are going to delete `next-comments-auth-service` in favour of `next-comments-api`. With this update, o-comments-beta will use `next-comments-api` for authenticating users.