### PR TITLE
ADSDEV-23: Track user and content via Permutive

### DIFF
--- a/assets/js/article.js
+++ b/assets/js/article.js
@@ -8,11 +8,15 @@ if (window.commentsTalkReplacement || window.commentsUseCoralTalk) {
 require('o-video');
 require('o-expander');
 
+const Permutive = require('./permutive');
 const oAds = require('alphaville-ui')['o-ads'];
 
 const embeddedMedia = require('webchat/src/js/ui/embeddedMedia');
 
-document.addEventListener('o.DOMContentLoaded', function () {
+const contentId = document.documentElement.dataset.contentId;
+Permutive.setUserAndPage(contentId);
+
+document.addEventListener('o.DOMContentLoaded', function async() {
 	const closedContentContainer = document.querySelector('.webchat-closed-content');
 
 	if (closedContentContainer) {

--- a/assets/js/permutive.js
+++ b/assets/js/permutive.js
@@ -1,0 +1,73 @@
+const oPermutive = require('o-permutive');
+const oAds = require('o-ads');
+
+const adsApiEndpoints = {
+	user: () => 'https://ads-api.ft.com/v2/user',
+	content: (contentId) => `https://ads-api.ft.com/v2/content/${contentId}`,
+}
+
+const getUser = () => {
+	return oAds.api.getUserData(adsApiEndpoints.user(), 250)
+		.catch((error) => {
+			console.warn('oPermutive: Could not identify user');
+			throw error;
+		})
+};
+
+const getContent = (contentId) => {
+	return oAds.api.getPageData(adsApiEndpoints.content(contentId), 250)
+		.catch((error) => {
+			console.warn('oPermutive: Could not set page metadata', error);
+		});
+}
+
+const identifyUser = (user) => {
+	if (user) {
+		oPermutive.identifyUser({
+			guid: user.uuid,
+			spoorID: user.spoorId,
+		});
+		return user;
+	}
+};
+
+const setPageMetaData = (content, user) => {
+	const pageMetaData = { type: 'article' };
+
+	if (content) {
+		pageMetaData.article = {
+			id: content.uuid,
+			// title,
+			// type,
+			organisations: content.organisation,
+			people: content.person,
+			categories: content.categories,
+			authors: content.person,
+			topics: content.topic,
+			admants: content.admants,
+		};
+	}
+
+	if (user) {
+		pageMetaData.user = {
+			industry: user.industry.code,
+			responsibility: user.responsibility.code,
+			position: user.position.code,
+		};
+	}
+
+	oPermutive.setPageMetaData(pageMetaData);
+};
+
+const setUserAndPage = (contentId) => {
+	getUser()
+		.then(identifyUser)
+		.then((user) => {
+			getContent(contentId)
+				.then((content) => setPageMetaData(content, user));
+		});
+}
+
+module.exports = {
+	setUserAndPage,
+};


### PR DESCRIPTION
See [ADSDEV-23: Implement Permutive on Alphaville](https://jira.ft.com/browse/ADSDEV-23)\

Retrieve use and content information and send it to Permutive for tracking.
Specifically:
* identifyUser: retrieve user demographics via Ads API v2 and send it to Permutive
* setPageMetaData: retrieve content data via Ads API v2 and send it to Permutive