### PR TITLE
ADSDEV-83 Remove Krux from Alphaville

### DIFF
--- a/assets/js/article.js
+++ b/assets/js/article.js
@@ -13,7 +13,7 @@ const contentId = document.documentElement.dataset.contentId;
 Permutive.setUserAndContent(contentId);
 Permutive.setPermutiveSegments();
 
-const oAds = require('alphaville-ui')['o-ads'];
+import { oAds } from 'alphaville-ui';
 
 const embeddedMedia = require('webchat/src/js/ui/embeddedMedia');
 

--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,7 @@
     "tests"
   ],
   "dependencies": {
-    "alphaville-ui": "Financial-Times/alphaville-ui#^2.3.0",
+    "alphaville-ui": "Financial-Times/alphaville-ui#^2.4.0",
     "alphaville-marketslive-chat": "Financial-Times/alphaville-marketslive-chat#^1.0.0",
     "webchat": "Financial-Times/webchat#^2.1.0",
     "o-autoinit": "^1.2.0",


### PR DESCRIPTION
See https://jira.ft.com/browse/ADSDEV-83

As part of removing Krux from Alphaville:
- Pin dependency to `alphaville-ui@2.4.0`
- Import `oAds` using import instead of require since `oAds@11`