### PR TITLE
Split service between Livefyre and Coral Talk

### DIFF
--- a/assets/js/article.js
+++ b/assets/js/article.js
@@ -1,6 +1,6 @@
 require('./common');
 // Temporary addition until comments are replaced
-if (document.querySelector('.o-comments')) {
+if (window.commentsUseCoralTalk) {
 	require('o-comments-beta');
 } else {
 	require('o-comments');

--- a/assets/js/article.js
+++ b/assets/js/article.js
@@ -1,6 +1,6 @@
 require('./common');
-if (window.commentsTalkReplacement || window.commentsUseCoralTalk) {
-	// Temporary addition until the comments are replaced
+// Temporary addition until comments are replaced
+if (document.querySelector('.o-comments')) {
 	require('o-comments-beta');
 } else {
 	require('o-comments');

--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,7 @@
     "webchat": "Financial-Times/webchat#^2.1.0",
     "o-autoinit": "^1.2.0",
     "o-comments": "^5.1.1",
-    "o-comments-beta": "https://github.com/Financial-Times/o-comments.git#v6.0.0-beta.26",
+    "o-comments-beta": "https://github.com/Financial-Times/o-comments.git#v6.0.0-beta.36",
     "o-tabs": "^4.0.0",
     "o-video": "^4.0.0",
     "o-expander": "^4.0.0",

--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,7 @@
     "tests"
   ],
   "dependencies": {
-    "alphaville-ui": "Financial-Times/alphaville-ui#^2.4.0",
+    "alphaville-ui": "Financial-Times/alphaville-ui#^2.5.0",
     "alphaville-marketslive-chat": "Financial-Times/alphaville-marketslive-chat#^1.0.0",
     "webchat": "Financial-Times/webchat#^2.1.0",
     "o-autoinit": "^1.2.0",

--- a/lib/controllers/articleCtrl.js
+++ b/lib/controllers/articleCtrl.js
@@ -64,6 +64,14 @@ exports.byVanity = function (req, res, next) {
 						.filter(item => !item.isFirstFT)
 						.shift())
 				.then(mostRecentPost => {
+					// Temporary addition until the comments are replaced
+					const commentsUseCoralMilestoneDate = process.env.COMMENTS_USE_CORAL_MILESTONE_DATE;
+					const commentsUseCoralTalk = process.env.COMMENTS_USE_CORAL_TALK === 'true';
+
+					let useCoralTalk = false;
+					if (commentsUseCoralMilestoneDate && commentsUseCoralTalk && article.firstPublishedDate > commentsUseCoralMilestoneDate) {
+						useCoralTalk = true;
+					}
 
 					res.render('article', {
 						title: article.title + ' | FT Alphaville',
@@ -74,6 +82,7 @@ exports.byVanity = function (req, res, next) {
 							articleSeriesUrl,
 							image: imageHelper
 						},
+						useCoralTalk,
 						oComments: true,
 						adZone: (article.seriesArticles && article.seriesArticles.series.prefLabel === 'Alphachat' ? 'alpha.chat' : undefined)
 					});

--- a/views/article.handlebars
+++ b/views/article.handlebars
@@ -121,7 +121,8 @@
                             id="comments"
                             data-o-component="o-comments"
                             data-o-comments-article-id="{{article.id}}"
-                            data-o-comments-story-url="{{@root.appUrl}}{{article.av2WebUrl}}">
+                            data-o-comments-story-url="{{@root.appUrl}}{{article.av2WebUrl}}"
+                            data-o-comments-source-app="alphaville-blogs-commentsUseCoralTalk">
                         </div>
                     {{else}}
                         <a name="comments"></a>

--- a/views/article.handlebars
+++ b/views/article.handlebars
@@ -110,8 +110,23 @@
                 </div>
 
                 {{#article.comments.enabled}}
-                    <a name="comments"></a>
-                    <div id="comments" data-o-component="o-comments" data-o-comments-config-title="{{article.originalTitle}}" data-o-comments-config-url="{{@root.appUrl}}{{article.av2WebUrl}}" data-o-comments-config-articleId="{{article.id}}"></div>
+                    {{#if useCoralTalk}}
+                        <a name="comments"></a>
+                        <div class="o-comments"
+                            id="comments"
+                            data-o-component="o-comments"
+                            data-o-comments-article-id="{{article.id}}"
+                            data-o-comments-story-url="{{@root.appUrl}}{{article.av2WebUrl}}">
+                        </div>
+                    {{else}}
+                        <a name="comments"></a>
+                        <div id="comments"
+                            data-o-component="o-comments"
+                            data-o-comments-config-title="{{article.originalTitle}}"
+                            data-o-comments-config-url="{{@root.appUrl}}{{article.av2WebUrl}}"
+                            data-o-comments-config-articleId="{{article.id}}">
+                        </div>
+                    {{/if}}
                 {{/article.comments.enabled}}
 
             </div>

--- a/views/article.handlebars
+++ b/views/article.handlebars
@@ -25,6 +25,11 @@
 	<link rel="stylesheet" href="{{assetsBasePath}}/build/article.css" />
 
 	<link rel="canonical" href="{{article.webUrl}}" />
+	{{#if useCoralTalk}}
+		<script>
+			window.commentsUseCoralTalk = true;
+		</script>
+	{{/if}}
 	<script>
 		(function () {
 			ctmLoadScript({


### PR DESCRIPTION
Stories that are older than the `COMMENTS_USE_CORAL_MILESTONE_DATE` will
render `o-comments` v5 while stories after that date will render
`o-comments` v6.

To test, set `COMMENTS_USE_CORAL_TALK=true` and `COMMENTS_USE_CORAL_MILESTONE_DATE=2019-09-25T00:00:00.000Z` in the `.env` file. Then run the app locally and you should see Coral rendered on articles published today and Livefyre rendered on articles published yesterday.