### PR TITLE
Allow beta comments to be tested in prod via query string

### DIFF
--- a/lib/controllers/articleCtrl.js
+++ b/lib/controllers/articleCtrl.js
@@ -67,9 +67,10 @@ exports.byVanity = function (req, res, next) {
 					// Temporary addition until the comments are replaced
 					const commentsUseCoralMilestoneDate = process.env.COMMENTS_USE_CORAL_MILESTONE_DATE;
 					const commentsUseCoralTalk = process.env.COMMENTS_USE_CORAL_TALK === 'true';
+					const commentsUseCoralTalkQuerystring = req.query.useCoralTalk;
 
 					let useCoralTalk = false;
-					if (commentsUseCoralMilestoneDate && commentsUseCoralTalk && article.firstPublishedDate > commentsUseCoralMilestoneDate) {
+					if ((commentsUseCoralMilestoneDate && commentsUseCoralTalk && article.firstPublishedDate > commentsUseCoralMilestoneDate) || commentsUseCoralTalkQuerystring) {
 						useCoralTalk = true;
 					}
 


### PR DESCRIPTION
By adding the useCoralTalk querystring you will be able to see the new
beta comments in production.