### PR TITLE
ADSDEV-226 Set user and page metadata in common.js

### DIFF
--- a/assets/js/article.js
+++ b/assets/js/article.js
@@ -17,11 +17,6 @@ if (window.commentsUseCoralTalk) {
 require('o-video');
 require('o-expander');
 
-const Permutive = require('alphaville-ui')['permutive'];
-const contentId = document.documentElement.dataset.contentId;
-Permutive.setUserAndContent(contentId);
-Permutive.setPermutiveSegments();
-
 import { oAds } from 'alphaville-ui';
 
 const embeddedMedia = require('webchat/src/js/ui/embeddedMedia');

--- a/assets/js/common.js
+++ b/assets/js/common.js
@@ -1,7 +1,3 @@
 require('./assets');
 require('alphaville-ui');
-
-const Permutive = require('alphaville-ui')['permutive'];
-Permutive.initPermutive();
-Permutive.setUser();
-Permutive.setPermutiveSegments();
+require('./permutive');

--- a/assets/js/permutive.js
+++ b/assets/js/permutive.js
@@ -1,0 +1,6 @@
+const contentId = document.documentElement.dataset.contentId;
+const Permutive = require('alphaville-ui')['permutive'];
+
+Permutive.initPermutive();
+Permutive.setUserAndContent(contentId);
+Permutive.setPermutiveSegments();

--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,7 @@
     "tests"
   ],
   "dependencies": {
-    "alphaville-ui": "Financial-Times/alphaville-ui#^2.5.0",
+    "alphaville-ui": "git@github.com:Financial-Times/alphaville-ui.git#ADSDEV-226_Alphaville_Pageview_event_not_passed_to_Permutive",
     "alphaville-marketslive-chat": "Financial-Times/alphaville-marketslive-chat#^1.0.0",
     "webchat": "Financial-Times/webchat#^2.1.0",
     "o-autoinit": "^1.2.0",

--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,7 @@
     "tests"
   ],
   "dependencies": {
-    "alphaville-ui": "git@github.com:Financial-Times/alphaville-ui.git#ADSDEV-226_Alphaville_Pageview_event_not_passed_to_Permutive",
+    "alphaville-ui": "Financial-Times/alphaville-ui#^2.6.0",
     "alphaville-marketslive-chat": "Financial-Times/alphaville-marketslive-chat#^1.0.0",
     "webchat": "Financial-Times/webchat#^2.1.0",
     "o-autoinit": "^1.2.0",


### PR DESCRIPTION
This is part of Jira ticket [#226 Alphaville - Pageview event not passed to Permutive](https://financialtimes.atlassian.net/browse/ADSDEV-226?atlOrigin=eyJpIjoiY2I4ZGE3MzY1MGZlNDZiY2ExMWM4NTg5Y2ZlOWM5MzQiLCJwIjoiaiJ9ADSDEV-226)

See also related PR [alphaville-ui #14](https://github.com/Financial-Times/alphaville-ui/pull/14)

## Description
`Permutive` is not working properly on Alphaville, specifically it is not firing the `PageView` event from Alphaville.

## Changes
Set user and page metadata in `common.js`.
