### PR TITLE
Use the canonical url for comments

### DIFF
--- a/views/article.handlebars
+++ b/views/article.handlebars
@@ -121,6 +121,7 @@
                             id="comments"
                             data-o-component="o-comments"
                             data-o-comments-article-id="{{article.id}}"
+                            data-o-comments-article-url="https://www.ft.com/content/{{article.id}}"
                             data-o-comments-source-app="alphaville-blogs-commentsUseCoralTalk">
                         </div>
                     {{else}}


### PR DESCRIPTION
Pass the same url on the front end as the url thats created by the
lambda which creates articles in Coral.

Related to this PR Financial-Times/comments-new-article-listener#10