### PR TITLE
Only render Coral comment count after migration date

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,7 +1,7 @@
 require('./common');
 require('o-expander');
 
-const oComments = require('o-comments');
+const oComments = require('o-comments-beta');
 const oVideo = require('o-video');
 const oDate = require('o-date');
 const alphavilleUi = require('alphaville-ui');

--- a/lib/controllers/indexListCtrl.js
+++ b/lib/controllers/indexListCtrl.js
@@ -40,6 +40,15 @@ module.exports = (req, res, next) => {
 			results.items.forEach((category) => {
 				if (category && category.items) {
 					category.items.forEach((article) => {
+						// Temporary addition until the comments are replaced
+						const commentsUseCoralMilestoneDate = process.env.COMMENTS_USE_CORAL_MILESTONE_DATE;
+						const commentsUseCoralTalk = process.env.COMMENTS_USE_CORAL_TALK === 'true';
+						const commentsUseCoralTalkQuerystring = req.query.useCoralTalk;
+
+						if ((commentsUseCoralMilestoneDate && commentsUseCoralTalk && article.firstPublishedDate > commentsUseCoralMilestoneDate) || commentsUseCoralTalkQuerystring) {
+							article.useCoralTalk = true;
+						}
+
 						if (index === 4) {
 							article.adAfter = 1;
 						}

--- a/views/article.handlebars
+++ b/views/article.handlebars
@@ -25,11 +25,6 @@
 	<link rel="stylesheet" href="{{assetsBasePath}}/build/article.css" />
 
 	<link rel="canonical" href="{{article.webUrl}}" />
-	{{#if useCoralTalk}}
-		<script>
-			window.commentsUseCoralTalk = true;
-		</script>
-	{{/if}}
 	<script>
 		(function () {
 			ctmLoadScript({
@@ -116,6 +111,9 @@
 
                 {{#article.comments.enabled}}
                     {{#if useCoralTalk}}
+                        <script>
+                            window.commentsUseCoralTalk = true;
+                        </script>
                         <a name="comments"></a>
                         <div class="o-comments"
                             id="comments"

--- a/views/partials/comment-counter.handlebars
+++ b/views/partials/comment-counter.handlebars
@@ -1,3 +1,11 @@
 {{#comments.enabled}}
-<a href="{{av2WebUrl}}#comments" class="alphaville-card--comment-counter" data-o-comments-config-hide-if-zero="false" data-o-component="o-comments" data-o-comments-count data-o-comments-config-article-id="{{id}}" data-o-comments-config-template="{count}" data-trackable="comment-count"></a>
+	{{#if useCoralTalk}}
+		<a href="{{av2WebUrl}}#comments"
+			class="o-comments alphaville-card--comment-counter"
+			data-o-component="o-comments"
+			data-o-comments-article-id="{{id}}"
+			data-o-comments-count="true"
+			data-trackable="comment-count">
+		</a>
+	{{/if}}
 {{/comments.enabled}}


### PR DESCRIPTION
We're unable to render both the Coral and Livefyre comment counts
on the Alphaville stream page because `o-comments` v5 conflicts with v6.

This PR only renders the Coral comment counts once the migration date
has passed.

Articles published before the migration date (Livefyre):
![image](https://user-images.githubusercontent.com/30316203/67305082-ba813580-f4ec-11e9-9618-38d82e04ee99.png)

Articles published after the migration date (Coral):
![image](https://user-images.githubusercontent.com/30316203/67305053-ae957380-f4ec-11e9-82eb-4a1fc19a6497.png)

