### PR TITLE
Remove comment count from Blogs stream page

### DIFF
--- a/views/partials/comment-counter.handlebars
+++ b/views/partials/comment-counter.handlebars
@@ -1,3 +1,9 @@
 {{#comments.enabled}}
-<a href="{{av2WebUrl}}#comments" class="alphaville-card--comment-counter" data-o-comments-config-hide-if-zero="false" data-o-component="o-comments" data-o-comments-count data-o-comments-config-article-id="{{id}}" data-o-comments-config-template="{count}" data-trackable="comment-count"></a>
+	<a href="{{av2WebUrl}}#comments"
+		class="o-comments alphaville-card--comment-counter"
+		data-o-component="o-comments"
+		data-o-comments-article-id="{{id}}"
+		data-o-comments-count="true"
+		data-trackable="comment-count">
+	</a>
 {{/comments.enabled}}

--- a/views/partials/grid-cards/card-alphachat.handlebars
+++ b/views/partials/grid-cards/card-alphachat.handlebars
@@ -12,7 +12,8 @@
 			{{/if}}
 
 			<div class="alphaville-card__footer">
-				{{> comment-counter}}
+				{{!-- Comment count will be reintroduced once migration is complete --}}
+				{{!-- {{> comment-counter}} --}}
 				{{> timestamp}}
 			</div>
 		</div>

--- a/views/partials/grid-cards/card-blog.handlebars
+++ b/views/partials/grid-cards/card-blog.handlebars
@@ -16,7 +16,8 @@
 			{{/if}}
 
 			<div class="alphaville-card__footer">
-				{{> comment-counter}}
+				{{!-- Comment count will be reintroduced once migration is complete --}}
+				{{!-- {{> comment-counter}} --}}
 				{{> timestamp}}
 			</div>
 		</div>

--- a/views/partials/grid-cards/card-firstft.handlebars
+++ b/views/partials/grid-cards/card-firstft.handlebars
@@ -11,7 +11,8 @@
 			{{> grid-cards/elements/heading}}
 
 			<div class="alphaville-card__footer">
-				{{> comment-counter}}
+				{{!-- Comment count will be reintroduced once migration is complete --}}
+				{{!-- {{> comment-counter}} --}}
 				{{> timestamp}}
 			</div>
 		</div>

--- a/views/partials/grid-cards/card-hero.handlebars
+++ b/views/partials/grid-cards/card-hero.handlebars
@@ -14,7 +14,8 @@
 			{{> grid-cards/elements/standfirst}}
 
 			<div class="alphaville-card__footer">
-				{{> comment-counter}}
+				{{!-- Comment count will be reintroduced once migration is complete --}}
+				{{!-- {{> comment-counter}} --}}
 				{{> timestamp}}
 			</div>
 		</div>

--- a/views/partials/grid-cards/card-imagelead.handlebars
+++ b/views/partials/grid-cards/card-imagelead.handlebars
@@ -9,7 +9,8 @@
 			{{> grid-cards/elements/heading}}
 
 			<div class="alphaville-card__footer">
-				{{> comment-counter}}
+				{{!-- Comment count will be reintroduced once migration is complete --}}
+				{{!-- {{> comment-counter}} --}}
 				{{> timestamp}}
 			</div>
 		</div>

--- a/views/partials/grid-cards/card-marketslive.handlebars
+++ b/views/partials/grid-cards/card-marketslive.handlebars
@@ -22,10 +22,11 @@
 			{{> grid-cards/elements/standfirst}}
 
 			<div class="alphaville-card__footer">
-				{{> comment-counter}}
+				{{!-- Comment count will be reintroduced once migration is complete --}}
+				{{!-- {{> comment-counter}} --}}
 				{{> timestamp}}
 			</div>
-			
+
 
 		</div>
 	</div>

--- a/views/partials/grid-cards/card-opinion.handlebars
+++ b/views/partials/grid-cards/card-opinion.handlebars
@@ -13,7 +13,8 @@
 			<div class="alphaville-card__footer">
 				<div class="o-grid-row">
 					<div data-o-grid-colspan="7 L8">
-						{{> comment-counter}}
+						{{!-- Comment count will be reintroduced once migration is complete --}}
+						{{!-- {{> comment-counter}} --}}
 						{{> timestamp}}
 					</div>
 				</div>

--- a/views/partials/list-cards/card-firstft.handlebars
+++ b/views/partials/list-cards/card-firstft.handlebars
@@ -16,18 +16,20 @@
 				<div class="alphaville-card__image">
 					<a href="{{av2WebUrl}}" data-trackable="image"><img src="{{image mainImage.url 740 'medium'}}" alt="{{mainImage.title}}" /></a>
 				</div>
-		
+
 				{{> grid-cards/elements/standfirst}}
 
 				<div class="alphaville-card__footer">
-					{{> comment-counter}}
+					{{!-- Comment count will be reintroduced once migration is complete --}}
+					{{!-- {{> comment-counter}} --}}
 					{{> timestamp}}
 				</div>
 			{{else}}
 				{{> grid-cards/elements/standfirst}}
 
 				<div class="alphaville-card__footer">
-					{{> comment-counter}}
+					{{!-- Comment count will be reintroduced once migration is complete --}}
+					{{!-- {{> comment-counter}} --}}
 					{{> timestamp}}
 				</div>
 			{{/if}}

--- a/views/partials/list-cards/card-generic.handlebars
+++ b/views/partials/list-cards/card-generic.handlebars
@@ -33,7 +33,8 @@
 					{{/rhr}}
 
 					<div class="alphaville-card__footer">
-						{{> comment-counter}}
+						{{!-- Comment count will be reintroduced once migration is complete --}}
+						{{!-- {{> comment-counter}} --}}
 						{{> timestamp}}
 						{{#byline}}
 							{{> byline}}
@@ -45,7 +46,8 @@
 					{{/rhr}}
 
 					<div class="alphaville-card__footer">
-						{{> comment-counter}}
+						{{!-- Comment count will be reintroduced once migration is complete --}}
+						{{!-- {{> comment-counter}} --}}
 						{{> timestamp}}
 						{{#byline}}
 							{{> byline}}

--- a/views/partials/list-cards/card-marketslive.handlebars
+++ b/views/partials/list-cards/card-marketslive.handlebars
@@ -18,7 +18,8 @@
 			{{> grid-cards/elements/standfirst}}
 
 			<div class="alphaville-card__footer">
-				{{> comment-counter}}
+				{{!-- Comment count will be reintroduced once migration is complete --}}
+				{{!-- {{> comment-counter}} --}}
 				{{> timestamp}}
 				{{#byline}}
 					{{> byline}}


### PR DESCRIPTION
We're unable to render both the Coral and Livefyre comment counts
on the Blogs stream page because `o-comments` v5 conflicts with v6.

While we are in the process of migrating to Coral, we are temporarily
removing the comment count. Once migration is complete, we will render
the Coral comment count.

Before:
![image](https://user-images.githubusercontent.com/30316203/67501497-49708800-f67c-11e9-8d74-fd9352959c14.png)

After:
![image](https://user-images.githubusercontent.com/30316203/67501413-26de6f00-f67c-11e9-9483-303b2dc9be75.png)
