### PR TITLE
Comments maintenance mode

### DIFF
--- a/assets/scss/components/article-page.scss
+++ b/assets/scss/components/article-page.scss
@@ -178,4 +178,11 @@
 	margin-bottom: $article-body-spacing-unit * 2;
 }
 
+.comments__maintenance-mode-message {
+	@include oTypographySans(0);
+
+	margin-top: $article-body-spacing-unit * 2;
+	margin-bottom: $article-body-spacing-unit * 2;
+}
+
 @import 'genre-styles';

--- a/lib/controllers/articleCtrl.js
+++ b/lib/controllers/articleCtrl.js
@@ -85,6 +85,7 @@ exports.byVanity = function (req, res, next) {
 						},
 						useCoralTalk,
 						oComments: true,
+						commentsMaintenanceMode: process.env.COMMENTS_MAINTENANCE_MODE === 'true',
 						adZone: (article.seriesArticles && article.seriesArticles.series.prefLabel === 'Alphachat' ? 'alpha.chat' : undefined)
 					});
 				});

--- a/views/article.handlebars
+++ b/views/article.handlebars
@@ -115,22 +115,28 @@
                 </div>
 
                 {{#article.comments.enabled}}
-                    {{#if useCoralTalk}}
-                        <a name="comments"></a>
-                        <div class="o-comments o-comments-stream"
-                            id="comments"
-                            data-o-component="o-comments"
-                            data-o-comments-article-id="{{article.id}}"
-                            data-o-comments-article-url="https://www.ft.com/content/{{article.id}}">
+                    {{#if commentsMaintenanceMode}}
+                        <div class="comments__maintenance-mode-message">
+                            There is a problem with reader comments. Our team is working on it. Please try again soon.
                         </div>
                     {{else}}
-                        <a name="comments"></a>
-                        <div id="comments"
-                            data-o-component="o-comments"
-                            data-o-comments-config-title="{{article.originalTitle}}"
-                            data-o-comments-config-url="{{@root.appUrl}}{{article.av2WebUrl}}"
-                            data-o-comments-config-articleId="{{article.id}}">
-                        </div>
+                        {{#if useCoralTalk}}
+                            <a name="comments"></a>
+                            <div class="o-comments o-comments-stream"
+                                id="comments"
+                                data-o-component="o-comments"
+                                data-o-comments-article-id="{{article.id}}"
+                                data-o-comments-article-url="https://www.ft.com/content/{{article.id}}">
+                            </div>
+                        {{else}}
+                            <a name="comments"></a>
+                            <div id="comments"
+                                data-o-component="o-comments"
+                                data-o-comments-config-title="{{article.originalTitle}}"
+                                data-o-comments-config-url="{{@root.appUrl}}{{article.av2WebUrl}}"
+                                data-o-comments-config-articleId="{{article.id}}">
+                            </div>
+                        {{/if}}
                     {{/if}}
                 {{/article.comments.enabled}}
 


### PR DESCRIPTION
When there is a technical issue with the comments, we want to display our users a friendly message instead of an error message or half loaded comments component.

When the environment variable is set `COMMENTS_MAINTENANCE_MODE=true` this message will be displayed:
<img width="829" alt="Screenshot 2019-11-20 at 16 00 23" src="https://user-images.githubusercontent.com/5130615/69261658-e1995880-0bb9-11ea-9b83-bff296c60fa4.png">
