### PR TITLE
Edit display name

### DIFF
--- a/assets/scss/components/article-page.scss
+++ b/assets/scss/components/article-page.scss
@@ -178,4 +178,21 @@
 	margin-bottom: $article-body-spacing-unit * 2;
 }
 
+.o-comments__signed-in-text {
+	@include oTypographySans($scale: 0);
+}
+
+.o-comments__signed-in-inner-text {
+	@include oTypographySans($scale: 2);
+	font-weight: bold;
+}
+
+.o-comments__signed-in-container {
+	margin-bottom: oSpacingByName('s4');
+}
+
+.o-comments__edit-display-name {
+	@include oTypographyLink;
+}
+
 @import 'genre-styles';

--- a/assets/scss/components/article-page.scss
+++ b/assets/scss/components/article-page.scss
@@ -178,21 +178,4 @@
 	margin-bottom: $article-body-spacing-unit * 2;
 }
 
-.o-comments__signed-in-text {
-	@include oTypographySans($scale: 0);
-}
-
-.o-comments__signed-in-inner-text {
-	@include oTypographySans($scale: 2);
-	font-weight: bold;
-}
-
-.o-comments__signed-in-container {
-	margin-bottom: oSpacingByName('s4');
-}
-
-.o-comments__edit-display-name {
-	@include oTypographyLink;
-}
-
 @import 'genre-styles';

--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
     "alphaville-marketslive-chat": "^2.0.0",
     "webchat": "^3.0.0",
     "o-autoinit": "^1.2.0",
-    "o-comments-beta": "https://github.com/Financial-Times/o-comments.git#v7.0.0",
+    "o-comments-beta": "https://github.com/Financial-Times/o-comments.git#v7.1.2",
     "o-comments": "https://github.com/Financial-Times/o-comments.git#major-cascade-breaking-v5",
     "o-tabs": "^5.0.0",
     "o-video": "^6.0.0",

--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
     "alphaville-marketslive-chat": "^2.0.0",
     "webchat": "^3.0.0",
     "o-autoinit": "^1.2.0",
-    "o-comments-beta": "https://github.com/Financial-Times/o-comments.git#v7.1.2",
+    "o-comments-beta": "https://github.com/Financial-Times/o-comments.git#v7.1.4",
     "o-comments": "https://github.com/Financial-Times/o-comments.git#major-cascade-breaking-v5",
     "o-tabs": "^5.0.0",
     "o-video": "^6.0.0",

--- a/views/article.handlebars
+++ b/views/article.handlebars
@@ -121,8 +121,7 @@
                             id="comments"
                             data-o-component="o-comments"
                             data-o-comments-article-id="{{article.id}}"
-                            data-o-comments-article-url="https://www.ft.com/content/{{article.id}}"
-                            data-o-comments-source-app="alphaville-blogs-commentsUseCoralTalk">
+                            data-o-comments-article-url="https://www.ft.com/content/{{article.id}}">
                         </div>
                     {{else}}
                         <a name="comments"></a>


### PR DESCRIPTION
Bumps o-comments to the latest and ~applies the styles~ for "signed in as" prompt.

No need to apply styles anymore. With o-comments#7.1.4, they come for free.