### PR TITLE
Comments migration message

### DIFF
--- a/lib/controllers/articleCtrl.js
+++ b/lib/controllers/articleCtrl.js
@@ -74,6 +74,14 @@ exports.byVanity = function (req, res, next) {
 						useCoralTalk = true;
 					}
 
+					// Temporary addition until comments migration is complete
+					const now = new Date().getTime();
+					const startOf2020 = 1577836800000; // 2020-01-01T00:00:00.000Z
+					let commentsMigrationMessage = false;
+					if (now >= startOf2020) {
+						commentsMigrationMessage = true;
+					}
+
 					res.render('article', {
 						title: article.title + ' | FT Alphaville',
 						article: article,
@@ -84,6 +92,7 @@ exports.byVanity = function (req, res, next) {
 							image: imageHelper
 						},
 						useCoralTalk,
+						commentsMigrationMessage,
 						oComments: true,
 						commentsMaintenanceMode: process.env.COMMENTS_MAINTENANCE_MODE === 'true',
 						adZone: (article.seriesArticles && article.seriesArticles.series.prefLabel === 'Alphachat' ? 'alpha.chat' : undefined)

--- a/lib/controllers/articleCtrl.js
+++ b/lib/controllers/articleCtrl.js
@@ -77,10 +77,7 @@ exports.byVanity = function (req, res, next) {
 					// Temporary addition until comments migration is complete
 					const now = new Date().getTime();
 					const startOf2020 = 1577836800000; // 2020-01-01T00:00:00.000Z
-					let commentsMigrationMessage = false;
-					if (now >= startOf2020) {
-						commentsMigrationMessage = true;
-					}
+					const commentsMigrationMessage = now >= startOf2020;
 
 					res.render('article', {
 						title: article.title + ' | FT Alphaville',

--- a/views/article.handlebars
+++ b/views/article.handlebars
@@ -129,13 +129,19 @@
                                 data-o-comments-article-url="https://www.ft.com/content/{{article.id}}">
                             </div>
                         {{else}}
-                            <a name="comments"></a>
-                            <div id="comments"
-                                data-o-component="o-comments"
-                                data-o-comments-config-title="{{article.originalTitle}}"
-                                data-o-comments-config-url="{{@root.appUrl}}{{article.av2WebUrl}}"
-                                data-o-comments-config-articleId="{{article.id}}">
-                            </div>
+                            {{#if commentsMigrationMessage}}
+                                <div class="comments__maintenance-mode-message">
+                                    We are migrating reader comments to our new system. It will be back soon.
+                                </div>
+                            {{else}}
+                                <a name="comments"></a>
+                                <div id="comments"
+                                    data-o-component="o-comments"
+                                    data-o-comments-config-title="{{article.originalTitle}}"
+                                    data-o-comments-config-url="{{@root.appUrl}}{{article.av2WebUrl}}"
+                                    data-o-comments-config-articleId="{{article.id}}">
+                                </div>
+                            {{/if}}
                         {{/if}}
                     {{/if}}
                 {{/article.comments.enabled}}


### PR DESCRIPTION
Livefyre service will stop at the end of 2019

In case we can't we can't complete comments migration we want to display a message in all Livefyre articles after the start 2020.