### PR TITLE
Update migration message copy

### DIFF
--- a/views/article.handlebars
+++ b/views/article.handlebars
@@ -131,7 +131,8 @@
                         {{else}}
                             {{#if commentsMigrationMessage}}
                                 <div class="comments__maintenance-mode-message">
-                                    We are migrating reader comments to our new system. It will be back soon.
+                                    <p>Commenting on this article is temporarily unavailable while we migrate to our new comments system.</p>
+                                    <p>Note that this only affects articles published before 28th October 2019.</p>
                                 </div>
                             {{else}}
                                 <a name="comments"></a>


### PR DESCRIPTION
This copy should only appear after 1/1/2020 and only on articles published before 28 October.