### PR TITLE
Migrate FT_Api_Key request header to FT-Api-Key

### DIFF
--- a/lib/services/sessionApi.js
+++ b/lib/services/sessionApi.js
@@ -5,7 +5,7 @@ const fetch = require('node-fetch');
 exports.getSessionData = function (sessionId) {
 	const options = {
 		headers: {
-			'FT_Api_Key': process.env.SESSION_API_KEY
+			'FT-Api-Key': process.env.SESSION_API_KEY
 		}
 	};
 


### PR DESCRIPTION
FT Core are deploying breaking changes in January 2020 which will deprecate the old api key syntax.

[Trello card](https://trello.com/c/KlYE2sSK/139-breaking-change-replace-where-ftapikey-header-is-used)