### PR TITLE
Remove old o-comments and replace with beta

### DIFF
--- a/assets/js/article.js
+++ b/assets/js/article.js
@@ -1,19 +1,15 @@
 require('./common');
 // Temporary addition until comments are replaced
 
-if (window.commentsUseCoralTalk) {
-	require('o-comments-beta');
+require('o-comments');
 
-	document.addEventListener('oComments.loginPrompt', () => {
-		const currentPath = new URL(location.href).pathname;
-		const commentsJumpAnchor = '#comments';
+document.addEventListener('oComments.loginPrompt', () => {
+	const currentPath = new URL(location.href).pathname;
+	const commentsJumpAnchor = '#comments';
 
-		location.href = `https://accounts.ft.com/login?location=${encodeURIComponent(currentPath)}${encodeURIComponent(commentsJumpAnchor)}`;
-	});
+	location.href = `https://accounts.ft.com/login?location=${encodeURIComponent(currentPath)}${encodeURIComponent(commentsJumpAnchor)}`;
+});
 
-} else {
-	require('o-comments');
-}
 require('o-video');
 require('o-expander');
 

--- a/assets/scss/article-page.scss
+++ b/assets/scss/article-page.scss
@@ -1,9 +1,6 @@
 @import './common';
 
 @import 'o-comments/main';
-$o-comments-is-silent: false;
-@import 'o-comments-beta/main';
-
 @import 'o-video/main';
 @import 'o-expander/main';
 

--- a/bower.json
+++ b/bower.json
@@ -21,8 +21,7 @@
   "dependencies": {
     "alphaville-ui": "^4.0.0",
     "o-autoinit": "^1.2.0",
-    "o-comments-beta": "https://github.com/Financial-Times/o-comments.git#v7.1.4",
-    "o-comments": "https://github.com/Financial-Times/o-comments.git#major-cascade-breaking-v5",
+    "o-comments": "^7.1.4",
     "o-tabs": "^5.0.0",
     "o-video": "^6.0.0",
     "o-expander": "^5.0.0",

--- a/lib/controllers/articleCtrl.js
+++ b/lib/controllers/articleCtrl.js
@@ -74,11 +74,6 @@ exports.byVanity = function (req, res, next) {
 						useCoralTalk = true;
 					}
 
-					// Temporary addition until comments migration is complete
-					const now = new Date().getTime();
-					const startOf2020 = 1577836800000; // 2020-01-01T00:00:00.000Z
-					const commentsMigrationMessage = now >= startOf2020;
-
 					res.render('article', {
 						title: article.title + ' | FT Alphaville',
 						article: article,
@@ -89,7 +84,6 @@ exports.byVanity = function (req, res, next) {
 							image: imageHelper
 						},
 						useCoralTalk,
-						commentsMigrationMessage,
 						oComments: true,
 						commentsMaintenanceMode: process.env.COMMENTS_MAINTENANCE_MODE === 'true',
 						adZone: (article.seriesArticles && article.seriesArticles.series.prefLabel === 'Alphachat' ? 'alpha.chat' : undefined)

--- a/views/article.handlebars
+++ b/views/article.handlebars
@@ -25,11 +25,6 @@
 	<link rel="stylesheet" href="{{assetsBasePath}}/build/article.css" />
 
 	<link rel="canonical" href="{{article.webUrl}}" />
-	{{#if useCoralTalk}}
-		<script>
-			window.commentsUseCoralTalk = true;
-		</script>
-	{{/if}}
 	<script>
 		(function () {
 			ctmLoadScript({
@@ -129,20 +124,10 @@
                                 data-o-comments-article-url="https://www.ft.com/content/{{article.id}}">
                             </div>
                         {{else}}
-                            {{#if commentsMigrationMessage}}
-                                <div class="comments__maintenance-mode-message">
-                                    <p>Commenting on this article is temporarily unavailable while we migrate to our new comments system.</p>
-                                    <p>Note that this only affects articles published before 28th October 2019.</p>
-                                </div>
-                            {{else}}
-                                <a name="comments"></a>
-                                <div id="comments"
-                                    data-o-component="o-comments"
-                                    data-o-comments-config-title="{{article.originalTitle}}"
-                                    data-o-comments-config-url="{{@root.appUrl}}{{article.av2WebUrl}}"
-                                    data-o-comments-config-articleId="{{article.id}}">
-                                </div>
-                            {{/if}}
+							<div class="comments__maintenance-mode-message">
+								<p>Commenting on this article is temporarily unavailable while we migrate to our new comments system.</p>
+								<p>Note that this only affects articles published before 28th October 2019.</p>
+							</div>
                         {{/if}}
                     {{/if}}
                 {{/article.comments.enabled}}


### PR DESCRIPTION
We no longer need to load livefyre comments onto the page and so we can
stop the use of two different versions and promote -beta to be the
stable version.