### PR TITLE
Load MarketsLive homepage content from file system

### DIFF
--- a/bin/www
+++ b/bin/www
@@ -10,6 +10,7 @@ const app = require('../app');
 const debug = require('debug')('alphaville-blogs:server');
 const http = require('http');
 const db = require('../lib/services/db');
+const { sortArticles } = require('../lib/utils/marketsLiveArticles');
 require('../lib/dbModels');
 const throng = require('throng');
 
@@ -36,7 +37,7 @@ function start() {
 		const gcMemory = Math.floor(parseInt(process.env.WEB_MEMORY, 10) * 4 / 5);
 		v8.setFlagsFromString(`--max_old_space_size=${gcMemory}`);
 	}
-	
+
 	/**
 	 * Get port from environment and store in Express.
 	 */
@@ -54,7 +55,13 @@ function start() {
 	 * Listen on provided port, on all network interfaces.
 	 */
 
-	db.connect(() => {
+	db.connect(async () => {
+		/**
+		 * Sort archived Marketslive articles before the app starts because, if you don't do this,
+		 * they will render on the page very slowly.
+		 */
+		await sortArticles();
+
 		server.listen(port, function () {
 			console.log('listening on port: ', port);
 		});

--- a/lib/controllers/marketsliveCtrl.js
+++ b/lib/controllers/marketsliveCtrl.js
@@ -3,6 +3,7 @@
 const articleService = require('../services/article');
 const pagination = require('../utils/pagination');
 const cacheHeaders = require('../utils/cacheHeaders');
+const { paginateArticles } = require('../utils/marketsLiveArticles');
 const fs = require('fs');
 const path = require('path');
 
@@ -18,17 +19,14 @@ exports.index = function(req, res, next) {
 		page = 1;
 	}
 
-	articleService
-		.getMarketsliveArticles({
-			limit: itemsPerPage,
-			offset: (page - 1) * itemsPerPage
-		})
-		.then(response => {
-			if (!response || !response.items.length) {
-				return next();
-			}
-
-			const transcripts = articleService.groupByTime(response);
+	paginateArticles({
+		limit: itemsPerPage,
+		offset: (page - 1) * itemsPerPage
+	})
+		.then(articles => {
+			const transcripts = articleService.groupByTime({
+				items: articles.paginatedArticles
+			});
 
 			let index = 0;
 			transcripts.items.forEach(category => {
@@ -47,7 +45,7 @@ exports.index = function(req, res, next) {
 				}
 			});
 
-			const totalPages = Math.ceil(response.total / itemsPerPage);
+			const totalPages = Math.ceil(articles.total / itemsPerPage);
 
 			res.render('ml-index', {
 				title: 'Marketslive index | FT Alphaville',

--- a/lib/services/article.js
+++ b/lib/services/article.js
@@ -323,7 +323,6 @@ const getArticles = (options, endpoint) => {
 exports.getArticles = (endpoint => (options) => getArticles(options, endpoint))('articles');
 exports.getArticlesByTopic = (endpoint => (options) => getArticles(options, endpoint))('topic');
 exports.getArticlesByAuthor = (endpoint => (options) => getArticles(options, endpoint))('author');
-exports.getMarketsliveArticles = (endpoint => (options) => getArticles(options, endpoint))('marketslive');
 exports.getHotArticles = (endpoint => (options) => getArticles(options, endpoint))('hotarticles');
 exports.getArticlesBySeries = (endpoint => (options) => getArticles(options, endpoint))('series');
 exports.getArticlesByType = (endpoint => (options) => getArticles(options, endpoint))('type');

--- a/lib/utils/marketsLiveArticles.js
+++ b/lib/utils/marketsLiveArticles.js
@@ -1,0 +1,47 @@
+const path = require('path');
+const fs = require('fs');
+
+let articles;
+
+const sortArticles = () => {
+	return new Promise((resolve) => {
+		const directory = path.join(__dirname, '../../content/markets-live/');
+		const marketsLiveArticles = [];
+
+		fs.readdir(directory, (error, files) => {
+			if (error) throw error;
+			const total = files.length;
+
+			files.forEach((file, index) => {
+				fs.readFile(directory + file, { encoding: 'utf-8' }, (error, data) => {
+					if (error) throw error;
+
+					const content = JSON.parse(data);
+					marketsLiveArticles.push(content);
+
+					articles = marketsLiveArticles.sort((a, b) => {
+						return new Date(b.publishedDate) - new Date(a.publishedDate);
+					});
+
+					if (index + 1 === total) {
+						resolve(articles);
+					}
+				});
+			});
+		});
+	});
+};
+
+const paginateArticles = (options) => {
+	return new Promise((resolve) => {
+		const total = articles.length;
+		const paginatedArticles = articles.slice(options.offset, (options.limit + options.offset));
+
+		resolve({ paginatedArticles, total });
+	});
+};
+
+module.exports = {
+	sortArticles,
+	paginateArticles
+}


### PR DESCRIPTION
The content needed for the Markets Live homepage is already available in
the archived Markets Live sessions so there's no need to get that info
from alphaville-es-interface-service.

This work came out of the need to remove the Markets Live API from
alphaville-es-interface-service. Fingers crossed, it should now be
easier to do that.

This work is related to the ongoing decommissioning of Markets Live,
see https://github.com/Financial-Times/next/issues/400.