### PR TITLE
Remove Markets Live API

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The fastest way to do this is to run the following assuming your are logged in i
 ```
 heroku config -s  >> .env --app av2-blogs-test
 ```
-Define the local database URL 
+Define the local database URL
 
 ```
 DATABASE_URL="mongodb://localhost:27017/av2-blogs-test"
@@ -94,7 +94,6 @@ In order you to be able to access articles without getting the barrier, you will
 
 ### Using alpavhille services together
 
-If you'd like to use other alphaville services locally with the blogs app (alphaville-es-interface-service, alphaville-marketslive-service), then you'll need to change their relevant environment variable, and change the URL and the relevant key to point to the local app you've set up:
+If you'd like to use other alphaville services locally with the blogs app (alphaville-es-interface-service), then you'll need to change their relevant environment variable, and change the URL and the relevant key to point to the local app you've set up:
 
 - `AV_ES_SERVICE_KEY` and `AV_ES_SERVICE_URL` for *alphaville-es-interface-service*
-- `ML_API_URL` for *alphaville-marketslive-service*

--- a/app.js
+++ b/app.js
@@ -8,9 +8,6 @@ const path = require('path');
 const healthcheck = require('./lib/health/healthchecks');
 const cacheHeaders = require('./lib/utils/cacheHeaders');
 
-const WpApi = require('alphaville-marketslive-wordpress-api');
-WpApi.setBaseUrl(process.env.WP_URL);
-
 const env = process.env.ENVIRONMENT === 'prod' ? 'prod' : 'test';
 
 const app = alphavilleExpress({

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "alphaville-auth-middleware": "Financial-Times/alphaville-auth-middleware#1.5.1",
     "alphaville-express": "Financial-Times/alphaville-express#1.1.1",
     "alphaville-header-config": "Financial-Times/alphaville-header-config#1.2.0",
-    "alphaville-marketslive-wordpress-api": "Financial-Times/alphaville-marketslive-wordpress-api#0.4.0",
     "alphaville-team-members": "Financial-Times/alphaville-team-members#1.0.0",
     "bluebird": "^3.4.1",
     "cheerio": "^0.20.0",


### PR DESCRIPTION
This work is related to the ongoing decommissioning of Markets Live,
see Financial-Times/next#400.