### PR TITLE
Update url and auth header for call to email platform API

### DIFF
--- a/lib/health/healthServices/emailService.js
+++ b/lib/health/healthServices/emailService.js
@@ -4,7 +4,7 @@ const _ = require('lodash');
 const url = require('url');
 
 const emailService = require('../../services/email');
-const emailServiceUrl = url.parse(process.env.EMAIL_SERVICE_API_URL);
+const emailServiceUrl = url.parse(process.env.EMAIL_PLATFORM_API_URL);
 
 const healthCheckModel = {
 	id: 'email-service',

--- a/lib/services/email.js
+++ b/lib/services/email.js
@@ -5,7 +5,7 @@ const fetch = require('node-fetch');
 exports.getUserData = function (userId) {
 	const options = {
 		headers: {
-			'Authorization': `Basic ${new Buffer(process.env.EMAIL_SERVICE_AUTH_USER + ':' + process.env.EMAIL_SERVICE_AUTH_PASS).toString('base64')}`
+			'Authorization': `Bearer ${process.env.EMAIL_PLATFORM_API_TOKEN}`
 		}
 	};
 

--- a/lib/services/email.js
+++ b/lib/services/email.js
@@ -9,8 +9,7 @@ exports.getUserData = function (userId) {
 		}
 	};
 
-	let url = process.env.EMAIL_SERVICE_API_URL;
-	url = url.replace(/\{userId\}/g, userId);
+	let url = `${process.env.EMAIL_PLATFORM_API_URL}/${userId}`;
 
 	return fetch(url, options).then((res) => {
 		if (res.ok) {


### PR DESCRIPTION
* Replace Email Service url

The email service has changed its url to ep.ft.com, and the current endpoint
"https://email-webservices.ft.com/users/{userId}?product=alphaville2" is no
longer live. This change renames the envvar and  replaces its value to hit the endpoint
"https://ep.ft.com/users-lists/users/:userUuid".

That endpoint is used to retrieve the user's email here:
https://github.com/Financial-Times/alphaville-blogs/blob/master/lib/middlewares/restrictedAccess.js#L43
and the email platform's API docs:
https://ep.ft.com/docs/users-lists/#api-User-GetUser indicate that the above
endpoint is the one that will return the user's email address.

* Authenticate with token
The email platform team has indicated that's their preferred way for us to
authenticate as it helps them track which apps are making requests. That also means we no longer need to add "?product=alphaville2" to the end of the url when calling it.

https://financialtimes.atlassian.net/jira/software/projects/NOPSCOPS/boards/952?selectedIssue=NOPSCOPS-130