### PR TITLE
Handle picture elements

### DIFF
--- a/assets/scss/components/article-content-body/partials/_images.scss
+++ b/assets/scss/components/article-content-body/partials/_images.scss
@@ -1,4 +1,5 @@
-.n-content-image {
+.n-content-image,
+.n-content-picture {
 	max-width: 100%;
 	clear: left;
 	page-break-inside: avoid;


### PR DESCRIPTION
If alphaville insert responsive images from charts (as they can now in Spark), the image isn't restricted at all, so expands to the size of the image.

This change applies the same styles as n-content-image, to restrict the width of the image inside picture elements.