### PR TITLE
Add cache control to __access_metadata endpoint

### DIFF
--- a/routes/__access_metadata.js
+++ b/routes/__access_metadata.js
@@ -62,6 +62,13 @@ setInterval(fetchFreeArticles, 60 * 1000);
 
 
 router.get('/__access_metadata', (req, res) => {
+	res.set({
+		'surrogate-control': `max-age=600`,
+		'stale-while-revalidate': 600,
+		'stale-if-error': 43200,
+		'cache-control': 'max-age=0, no-cache, must-revalidate'
+	});
+
 	res.json({
 		access_metadata: [].concat(wpAccessMetadata).concat(av2AccessMetadata)
 	});


### PR DESCRIPTION
This endpoint is used by access service. Membership team requested us to review the cache policy for it.

Since the response is quite static in nature, we want to put a long cache for this endpoint.