### PR TITLE
ADSDEV-449 Use n-permutive for Alphaville

### DIFF
--- a/assets/js/permutive.js
+++ b/assets/js/permutive.js
@@ -1,6 +1,22 @@
-const contentId = document.documentElement.dataset.contentId;
-const Permutive = require('alphaville-ui')['permutive'];
+const nPermutive = require('n-permutive');
 
-Permutive.initPermutive();
-Permutive.setUserAndContent(contentId);
-Permutive.setPermutiveSegments();
+const PERMUTIVE_CREDENTIALS = {
+	publicId: 'e1c3fd73-dd41-4abd-b80b-4278d52bf7aa',
+	publicApikey: 'b2b3b748-e1f6-4bd5-b2f2-26debc8075a3',
+}
+
+const getAppName = targeting => targeting && targeting.auuid
+	? 'article'
+	: 'homepage';
+
+nPermutive.setup(PERMUTIVE_CREDENTIALS);
+nPermutive.loadPermutiveScript(PERMUTIVE_CREDENTIALS.publicId);
+
+// Wait for oAds to complete initialisation, in order to access the targeting meta
+// and Then identify the user and track PageView
+oAds.utils.on('initialised', () => {
+	const targeting = oAds.targeting.get();
+
+	nPermutive.identifyUser(targeting);
+	nPermutive.trackPageView(targeting, getAppName(targeting), oAds.config('behavioralMeta'));
+})

--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,7 @@
 		"tests"
 	],
 	"dependencies": {
-		"alphaville-ui": "git://github.com/Financial-Times/alphaville-ui#ADSDEV-449_use_n-permutive_instead_of_o-permutive",
+		"alphaville-ui": "^5.0.0",
 		"o-autoinit": "^1.2.0",
 		"o-comments": "^7.3.0",
 		"o-tabs": "^5.0.0",

--- a/bower.json
+++ b/bower.json
@@ -1,37 +1,37 @@
 {
-  "name": "alphaville-blogs",
-  "description": "",
-  "main": "",
-  "authors": [
-    "Dragos Digulescu <dragos.digulescu@ft.com>",
-    "Roland Vachter <roland.vachter@ft.com>"
-  ],
-  "homepage": "https://github.com/Financial-Times/alphaville-blogs",
-  "moduleType": [
-    "globals"
-  ],
-  "private": true,
-  "ignore": [
-    "**/.*",
-    "node_modules",
-    "bower_components",
-    "test",
-    "tests"
-  ],
-  "dependencies": {
-    "alphaville-ui": "^4.0.0",
-    "o-autoinit": "^1.2.0",
-    "o-comments": "^7.3.0",
-    "o-tabs": "^5.0.0",
-    "o-video": "^6.0.0",
-    "o-expander": "^5.0.0",
-    "o-forms": "^8.0.0",
-    "o-colors": "^5.0.0",
-    "o-buttons": "^6.0.2",
-    "ftdomdelegate": "^4.0.0",
-    "o-editorial-typography": "^1.0.0",
-    "o-ads": "^14.0.0",
-    "o-normalise": "^2.0.0",
-    "o-date": "^4.0.0"
-  }
+	"name": "alphaville-blogs",
+	"description": "",
+	"main": "",
+	"authors": [
+		"Dragos Digulescu <dragos.digulescu@ft.com>",
+		"Roland Vachter <roland.vachter@ft.com>"
+	],
+	"homepage": "https://github.com/Financial-Times/alphaville-blogs",
+	"moduleType": [
+		"globals"
+	],
+	"private": true,
+	"ignore": [
+		"**/.*",
+		"node_modules",
+		"bower_components",
+		"test",
+		"tests"
+	],
+	"dependencies": {
+		"alphaville-ui": "git://github.com/Financial-Times/alphaville-ui#ADSDEV-449_use_n-permutive_instead_of_o-permutive",
+		"o-autoinit": "^1.2.0",
+		"o-comments": "^7.3.0",
+		"o-tabs": "^5.0.0",
+		"o-video": "^6.0.0",
+		"o-expander": "^5.0.0",
+		"o-forms": "^8.0.0",
+		"o-colors": "^5.0.0",
+		"o-buttons": "^6.0.2",
+		"ftdomdelegate": "^4.0.0",
+		"o-editorial-typography": "^1.0.0",
+		"o-ads": "^14.0.0",
+		"o-normalise": "^2.0.0",
+		"o-date": "^4.0.0"
+	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10346,6 +10346,11 @@
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
     },
+    "n-permutive": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/n-permutive/-/n-permutive-2.3.0.tgz",
+      "integrity": "sha512-dXSzm1cow5BBZ1cbDroOVPzuAC5VHh6W9/esZLBWVNoir8Wnm5ngJd+1j0C9M28b2+DvTRPAoMMW/L+k+6dlqg=="
+    },
     "nan": {
       "version": "2.14.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "memory-cache": "^0.1.6",
     "moment-timezone": "^0.5.5",
     "mongoose": "^4.6.0",
-    "n-permutive": "^2.3.0",
+    "n-permutive": "^2.3.2",
     "node-fetch": "^1.5.2",
     "pg-promise": "^8.5.3",
     "pusher-client": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "memory-cache": "^0.1.6",
     "moment-timezone": "^0.5.5",
     "mongoose": "^4.6.0",
+    "n-permutive": "^2.3.0",
     "node-fetch": "^1.5.2",
     "pg-promise": "^8.5.3",
     "pusher-client": "^1.1.0",


### PR DESCRIPTION
## Meta
Part of Jira [ADSDEV-449 Use n-permutive for alphaville][ADSDEV-449]

## Description
We are now using directly `n-permutive`, instead of the helper module `permutive` exported via alphaville-ui, which was a wrapper around `o-permutive`.

It awaits for oAds's `initialised` event to be thrown, in order to access the targeting exposed by oAds and then identifying the user and track the PageView

## Release notes
Depends on `alphaville@5.x`, which includes this changes https://github.com/Financial-Times/alphaville-ui/pull/27

[ADSDEV-449]: https://financialtimes.atlassian.net/browse/ADSDEV-449
