### PR TITLE
Remove comments migration code

### DIFF
--- a/lib/controllers/articleCtrl.js
+++ b/lib/controllers/articleCtrl.js
@@ -64,16 +64,6 @@ exports.byVanity = function (req, res, next) {
 						.filter(item => !item.isFirstFT)
 						.shift())
 				.then(mostRecentPost => {
-					// Temporary addition until the comments are replaced
-					const commentsUseCoralMilestoneDate = process.env.COMMENTS_USE_CORAL_MILESTONE_DATE;
-					const commentsUseCoralTalk = process.env.COMMENTS_USE_CORAL_TALK === 'true';
-					const commentsUseCoralTalkQuerystring = req.query.useCoralTalk;
-
-					let useCoralTalk = false;
-					if ((commentsUseCoralMilestoneDate && commentsUseCoralTalk && article.firstPublishedDate > commentsUseCoralMilestoneDate) || commentsUseCoralTalkQuerystring) {
-						useCoralTalk = true;
-					}
-
 					res.render('article', {
 						title: article.title + ' | FT Alphaville',
 						article: article,
@@ -83,7 +73,6 @@ exports.byVanity = function (req, res, next) {
 							articleSeriesUrl,
 							image: imageHelper
 						},
-						useCoralTalk,
 						oComments: true,
 						commentsMaintenanceMode: process.env.COMMENTS_MAINTENANCE_MODE === 'true',
 						adZone: (article.seriesArticles && article.seriesArticles.series.prefLabel === 'Alphachat' ? 'alpha.chat' : undefined)

--- a/views/article.handlebars
+++ b/views/article.handlebars
@@ -115,20 +115,13 @@
                             There is a problem with reader comments. Our team is working on it. Please try again soon.
                         </div>
                     {{else}}
-                        {{#if useCoralTalk}}
-                            <a name="comments"></a>
-                            <div class="o-comments o-comments-stream"
-                                id="comments"
-                                data-o-component="o-comments"
-                                data-o-comments-article-id="{{article.id}}"
-                                data-o-comments-article-url="https://www.ft.com/content/{{article.id}}">
-                            </div>
-                        {{else}}
-							<div class="comments__maintenance-mode-message">
-								<p>Commenting on this article is temporarily unavailable while we migrate to our new comments system.</p>
-								<p>Note that this only affects articles published before 28th October 2019.</p>
-							</div>
-                        {{/if}}
+                        <a name="comments"></a>
+                        <div class="o-comments o-comments-stream"
+                            id="comments"
+                            data-o-component="o-comments"
+                            data-o-comments-article-id="{{article.id}}"
+                            data-o-comments-article-url="https://www.ft.com/content/{{article.id}}">
+                        </div>
                     {{/if}}
                 {{/article.comments.enabled}}
 


### PR DESCRIPTION
Since the comments data migration from Livefyre to Coral is complete, we can remove the migration message and cleanup the related logic.