### PR TITLE
ADSDEV-407 Update to n-permutive@2.4.0

### DIFF
--- a/assets/js/common.js
+++ b/assets/js/common.js
@@ -1,3 +1,3 @@
 require('./assets');
-require('alphaville-ui');
 require('./permutive');
+require('alphaville-ui');

--- a/assets/js/permutive.js
+++ b/assets/js/permutive.js
@@ -14,7 +14,7 @@ nPermutive.loadPermutiveScript(PERMUTIVE_CREDENTIALS.publicId);
 
 // Wait for oAds to complete initialisation, in order to access the targeting meta
 // and Then identify the user and track PageView
-oAds.utils.on('initialised', () => {
+document.body.addEventListener('oAds.initialised', () => {
 	const targeting = oAds.targeting.get();
 
 	nPermutive.identifyUser(targeting);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10347,9 +10347,25 @@
       "dev": true
     },
     "n-permutive": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/n-permutive/-/n-permutive-2.3.0.tgz",
-      "integrity": "sha512-dXSzm1cow5BBZ1cbDroOVPzuAC5VHh6W9/esZLBWVNoir8Wnm5ngJd+1j0C9M28b2+DvTRPAoMMW/L+k+6dlqg=="
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/n-permutive/-/n-permutive-2.4.0.tgz",
+      "integrity": "sha512-K6wpnOfB0mqR39gkjmWNmZNhu8zMYCXUDcAxWiRBFsPDvY29RahKhYpGADM6YoTPJnwaLkAELaGJv1TGK9b+sw==",
+      "requires": {
+        "core-js": "^3.6.5",
+        "regenerator-runtime": "^0.13.5"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "3.6.5",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+          "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
+        },
+        "regenerator-runtime": {
+          "version": "0.13.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+        }
+      }
     },
     "nan": {
       "version": "2.14.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "memory-cache": "^0.1.6",
     "moment-timezone": "^0.5.5",
     "mongoose": "^4.6.0",
-    "n-permutive": "^2.3.2",
+    "n-permutive": "^2.4.0",
     "node-fetch": "^1.5.2",
     "pg-promise": "^8.5.3",
     "pusher-client": "^1.1.0",


### PR DESCRIPTION
## Meta
[ADSDEV-407][ADSDEV-407]

## Description
Use the latest `n-permutive@2.4.0`, which adds permutive's view-id to ads targeting.
Also listen to event `oAds.initialised` before running any code that relies on oAds.

[ADSDEV-407]: https://financialtimes.atlassian.net/browse/ADSDEV-407