### PR TITLE
Fix email service severity 3 healthcheck

### DIFF
--- a/lib/health/healthServices/emailService.js
+++ b/lib/health/healthServices/emailService.js
@@ -22,7 +22,7 @@ exports.getHealth = function () {
 	return new Promise((resolve) => {
 		const currentHealth = _.clone(healthCheckModel);
 
-		emailService.getUserData('3f330864-1c0f-443e-a6b3-cf8a3b536a52')
+		emailService.getUserData('75ff956e-c349-4a19-aff7-8d6bec8fe690')
 			.then(() => {
 				currentHealth.ok = true;
 				resolve(_.omit(currentHealth, ['checkOutput']));

--- a/lib/health/healthServices/emailService.js
+++ b/lib/health/healthServices/emailService.js
@@ -14,7 +14,7 @@ const healthCheckModel = {
 	severity: 3,
 	businessImpact: "Curation tool not accessible.",
 	checkOutput: "",
-	panicGuide: `Check the healthcheck of the service (https://${emailServiceUrl.host}/__health)`,
+	panicGuide: `Check the healthcheck of the service (https://ep.ft.com/users-lists/__health)`,
 	lastUpdated: new Date().toISOString()
 };
 


### PR DESCRIPTION
This healthcheck was failing as the uuid of the user belongs to a former FT
employee or contractor so the email service doesn't know about them anymore. 

The new uuid belongs to a test premium user we use in
next-test-sessions-lambda so more reliable. When running the request in Postman
with that uuid, it returns a 200 so should work!

https://financialtimes.atlassian.net/secure/RapidBoard.jspa?rapidView=1137&projectKey=NOPS&modal=detail&selectedIssue=NOPS-332