### PR TITLE
ADSDEV-603 Permutive: identify User only by GUID

### DIFF
--- a/assets/js/permutive.js
+++ b/assets/js/permutive.js
@@ -1,22 +1,21 @@
-const nPermutive = require('n-permutive');
+const nPermutive = require('n-permutive').default;
 
-const PERMUTIVE_CREDENTIALS = {
-	publicId: 'e1c3fd73-dd41-4abd-b80b-4278d52bf7aa',
-	publicApikey: 'b2b3b748-e1f6-4bd5-b2f2-26debc8075a3',
-}
-
-const getAppName = targeting => targeting && targeting.auuid
+const getPageViewType = pageView => pageView && pageView.article
 	? 'article'
-	: 'homepage';
+	: 'homepage'
 
-nPermutive.setup(PERMUTIVE_CREDENTIALS);
-nPermutive.loadPermutiveScript(PERMUTIVE_CREDENTIALS.publicId);
+nPermutive.setup();
+nPermutive.loadPermutiveScript();
 
 // Wait for oAds to complete initialisation, in order to access the targeting meta
 // and Then identify the user and track PageView
 document.body.addEventListener('oAds.initialised', () => {
-	const targeting = oAds.targeting.get();
+	const [user, article] = oAds.api.data;
+	const pageView = nPermutive.fromAdsApiV1ToPageView({ user, article });
 
-	nPermutive.identifyUser(targeting);
-	nPermutive.trackPageView(targeting, getAppName(targeting), oAds.config('behavioralMeta'));
+	nPermutive.identifyUser({
+		uuid: user && user.guid
+	});
+	pageView && pageView.page && (pageView.page.type = getPageViewType());
+	nPermutive.trackPageView(pageView);
 })

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "memory-cache": "^0.1.6",
     "moment-timezone": "^0.5.5",
     "mongoose": "^4.6.0",
-    "n-permutive": "^2.4.1",
+    "n-permutive": "^3.1.0",
     "node-fetch": "^1.5.2",
     "pg-promise": "^8.5.3",
     "pusher-client": "^1.1.0",


### PR DESCRIPTION
## Meta
[ADSDEV-603][ADSDEV-603]

## Description
Ads Data Ops wants to identify a user in the Permutive realm only by `guid`.

This PR requires to upgrade from `n-permutive@2.x` to the latest version of `n-permutive@3.x`, which has updated the exposed functionalities. Specifically, `trackPageView()` now accepts data in Permutive's schema format.
Alphaville apps are still using o-ads@14, which caches the Ads API responses and exposes them through `ads.api.data`.

This work is based on [n-permutive][n-permutive]'s guide to [How to use an Ads Data Formatter][permutive_using_formatter] - specifically the example on using the Ads Data V1 formatter.

[ADSDEV-603]: https://financialtimes.atlassian.net/browse/ADSDEV-603
[n-permutive]: https://github.com/Financial-Times/n-permutive
[permutive_using_formatter]: https://github.com/Financial-Times/n-permutive/tree/02eb173259b21d27eff743cf5f38189f3c9c287a#using-a-formatter